### PR TITLE
guacamoleb: remove forced gapps

### DIFF
--- a/krypton_guacamoleb.mk
+++ b/krypton_guacamoleb.mk
@@ -25,9 +25,6 @@ PRODUCT_AAPT_CONFIG := xxhdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 PRODUCT_CHARACTERISTICS := nosdcard
 
-#GAPPS
-GAPPS_BUILD := true
-
 # Boot animation
 scr_resolution := 1080
 TARGET_SCREEN_HEIGHT := 2240


### PR DESCRIPTION
KOSP provides buildtime support for building with gapps via the `-g` flag, these lines removed support for building without them